### PR TITLE
Exclusion fichier config.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/osx,windows,linux,visualstudiocode
 avatars
+includes/config.php


### PR DESCRIPTION
Le fichier contenant les configuration permettant la connexion à la base de données est exclu.